### PR TITLE
[github-desktop] update PKGBUILD to workaround missing submodules

### DIFF
--- a/github-desktop/.SRCINFO
+++ b/github-desktop/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = github-desktop
 	pkgdesc = GUI for managing Git and GitHub
-	pkgver = 2.9.0
-	pkgrel = 3
+	pkgver = 2.9.2
+	pkgrel = 1
 	url = https://desktop.github.com
 	arch = x86_64
 	license = MIT
@@ -21,7 +21,7 @@ pkgbase = github-desktop
 	depends = unzip
 	optdepends = github-cli: CLI interface for GitHub
 	optdepends = hub: CLI interface for GitHub
-	source = github-desktop::git+https://github.com/shiftkey/desktop.git#tag=release-2.9.0-linux4
+	source = github-desktop::git+https://github.com/shiftkey/desktop.git#tag=release-2.9.2-linux1
 	source = github-desktop.desktop
 	sha256sums = SKIP
 	sha256sums = 932e4c456e8c6db03d27172cf0daa37806bf025bb560d8b3d758c0997d1a618c

--- a/github-desktop/.SRCINFO
+++ b/github-desktop/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = github-desktop
 	pkgdesc = GUI for managing Git and GitHub
 	pkgver = 2.9.2
-	pkgrel = 1
+	pkgrel = 2
 	url = https://desktop.github.com
 	arch = x86_64
 	license = MIT
@@ -22,7 +22,13 @@ pkgbase = github-desktop
 	optdepends = github-cli: CLI interface for GitHub
 	optdepends = hub: CLI interface for GitHub
 	source = github-desktop::git+https://github.com/shiftkey/desktop.git#tag=release-2.9.2-linux1
+	source = git+https://github.com/github/gemoji.git
+	source = git+https://github.com/github/gitignore.git
+	source = git+https://github.com/github/choosealicense.com.git
 	source = github-desktop.desktop
+	sha256sums = SKIP
+	sha256sums = SKIP
+	sha256sums = SKIP
 	sha256sums = SKIP
 	sha256sums = 932e4c456e8c6db03d27172cf0daa37806bf025bb560d8b3d758c0997d1a618c
 

--- a/github-desktop/PKGBUILD
+++ b/github-desktop/PKGBUILD
@@ -4,9 +4,9 @@
 # Contributor: Jiawen Geng
 
 pkgname=github-desktop
-pkgver=2.9.0
-_gitname="release-$pkgver-linux4"
-pkgrel=3
+pkgver=2.9.2
+_gitname="release-$pkgver-linux1"
+pkgrel=1
 pkgdesc='GUI for managing Git and GitHub'
 arch=(x86_64)
 url='https://desktop.github.com'
@@ -35,6 +35,7 @@ sha256sums=('SKIP'
 
 build() {
     cd "$pkgname"
+    git submodule update --recursive --init
     export DISPLAY=':99.0'
     Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
     yarn install

--- a/github-desktop/PKGBUILD
+++ b/github-desktop/PKGBUILD
@@ -6,7 +6,7 @@
 pkgname=github-desktop
 pkgver=2.9.2
 _gitname="release-$pkgver-linux1"
-pkgrel=1
+pkgrel=2
 pkgdesc='GUI for managing Git and GitHub'
 arch=(x86_64)
 url='https://desktop.github.com'
@@ -29,13 +29,27 @@ makedepends=('nodejs>=10.16.0'
              yarn)
 DLAGENTS=("http::/usr/bin/git clone --branch $_gitname --single-branch %u")
 source=("$pkgname::git+https://github.com/shiftkey/desktop.git#tag=$_gitname"
+        'git+https://github.com/github/gemoji.git'
+        'git+https://github.com/github/gitignore.git'
+        'git+https://github.com/github/choosealicense.com.git'
         "$pkgname.desktop")
 sha256sums=('SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
             '932e4c456e8c6db03d27172cf0daa37806bf025bb560d8b3d758c0997d1a618c')
+
+prepare() {
+    cd "$pkgname"
+    git submodule init
+    git config submodule."gemoji".url "$srcdir/gemoji"
+    git config submodule."app/static/common/gitignore".url "$srcdir/gitignore"
+    git config submodule."app/static/common/choosealicense.com".url "$srcdir/choosealicense.com"
+    git submodule update
+}
 
 build() {
     cd "$pkgname"
-    git submodule update --recursive --init
     export DISPLAY=':99.0'
     Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
     yarn install


### PR DESCRIPTION
Spotted this comment over in the [AUR feed](https://aur.archlinux.org/packages/github-desktop/#comment-823824):

>  Something goes wrong during the webpack stage in relation to emoji or something. 

:wave: GitHub Desktop Linux maintainer here. I was working previously with `immackay` on this package, and I think I know what's happening here. The tooling has a post-install script that ensures it has submodules on disk, but we wrapped that in an online check to support Flatpak, which was recently enabled:

https://github.com/shiftkey/desktop/blob/c04d1aeb46aa87953531aa83ce96d1c120281b21/script/post-install.ts#L56-L66

```ts
  if (isOffline()) {
    result = spawnSync(
      'git',
      ['submodule', 'update', '--recursive', '--init'],
      options
    )
    ...
  }
```

Where `isOffline()` is looking for an `OFFLINE=1` environment variable:

https://github.com/shiftkey/desktop/blob/c04d1aeb46aa87953531aa83ce96d1c120281b21/script/post-install.ts#L15-L18

```ts
/** Check if the caller has set the OFFLINe environment variable */
function isOffline() {
  return process.env.OFFLINE === '1'
}
```

But that's been in place with the `2.9.0-linux4` build you have working, so perhaps something's changed upstream of me that I didn't expect. 

Anyway, the workaround for this is to ensure the submodules are created before doing `yarn build:prod`. I thought `DLAGENTS` was the right place to add `--recurse-submodules` but I don't see that working when I tested it on https://github.com/immackay/github-desktop-aur/pull/16, and had to fall back to this approach.

I've bumped the package release to `2.9.2-linux1` to confirm this is resolved, but I've verified it over in the `immackay/github-desktop-aur` repo (which runs the changes through `makepkg`), but I'm also surprised that this isn't requiring Node 14 or later for building. But I guess we'll see how CI goes...