### PR TITLE
[mattermost-desktop] use electron14 and upgrade builder to 22.14.5

### DIFF
--- a/mattermost-desktop/.SRCINFO
+++ b/mattermost-desktop/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = mattermost-desktop
 	pkgdesc = Mattermost Desktop application for Linux
 	pkgver = 5.0.2
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/mattermost/desktop
 	arch = x86_64
 	arch = i686
@@ -10,7 +10,7 @@ pkgbase = mattermost-desktop
 	makedepends = jq
 	makedepends = moreutils
 	makedepends = npm
-	depends = electron12
+	depends = electron14
 	source = mattermost-desktop-5.0.2.tar.gz::https://github.com/mattermost/desktop/archive/v5.0.2.tar.gz
 	source = mattermost-desktop.sh
 	source = mattermost.desktop

--- a/mattermost-desktop/PKGBUILD
+++ b/mattermost-desktop/PKGBUILD
@@ -7,13 +7,13 @@
 
 pkgname=mattermost-desktop
 pkgver=5.0.2
-pkgrel=1
+pkgrel=2
 pkgdesc='Mattermost Desktop application for Linux'
 arch=(x86_64 i686)
 url="https://github.com/${pkgname/-//}"
 license=(Apache)
-_electron=electron12
-_builderVersion='^20.10.4'
+_electron=electron14
+_builderVersion='^22.14.5'
 depends=($_electron)
 makedepends=(git jq moreutils npm)
 source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz"


### PR DESCRIPTION
Use Electron 14. Also upgrade builder to `22.14.5`.
This has been tested in a clean environment and functions when installed.