### PR TITLE
PKGBULD: install missing files

### DIFF
--- a/typecatcher/.SRCINFO
+++ b/typecatcher/.SRCINFO
@@ -1,12 +1,11 @@
 pkgbase = typecatcher
 	pkgdesc = Download Google webfonts for off-line use
 	pkgver = 0.4
-	pkgrel = 2
+	pkgrel = 3
 	url = https://github.com/andrewsomething/typecatcher
 	arch = any
 	license = GPL3
 	makedepends = python-distutils-extra
-	depends = gobject-introspection
 	depends = gtk3
 	depends = python
 	depends = python-gobject

--- a/typecatcher/PKGBUILD
+++ b/typecatcher/PKGBUILD
@@ -4,13 +4,12 @@
 
 pkgname=typecatcher
 pkgver=0.4
-pkgrel=2
+pkgrel=3
 pkgdesc='Download Google webfonts for off-line use'
 arch=(any)
 url="https://github.com/andrewsomething/$pkgname"
 license=(GPL3)
-depends=(gobject-introspection
-         gtk3
+depends=(gtk3
          python
          python-gobject
          webkit2gtk
@@ -23,8 +22,10 @@ sha256sums=('8b7b78bac166c64f12de1314e5aea2791cb5628ca27447eb29efc408c50c36e7')
 
 prepare() {
 	cd "$_archive"
+
 	# Remove Ubuntu specific crash handler
-	rm -rf apport
+	rm -rf apport etc
+
 	# Ignore broken distuils stuff (desktop file installs fail)
 	sed -i -e '/sys.exit/d' setup.py
 }
@@ -37,6 +38,20 @@ build() {
 package() {
 	cd "$_archive"
 	python setup.py install --root="$pkgdir" --optimize=1 --skip-build
-	install -Dm0644 -t "$pkgdir/usr/share/licenses/$pkgname/" COPYING
+
 	install -Dm0644 -t "$pkgdir/usr/share/doc/$pkgname/" AUTHORS
+
+	# Install files DistUtils fails to install
+	install -d "$pkgdir/usr/share/locale"
+	cp -r build/mo/* "$pkgdir/usr/share/locale"
+
+	install -d "$pkgdir/usr/share/help/C/$pkgname"
+	cp -r help/C/* "$pkgdir/usr/share/help/C/$pkgname/"
+
+	install -Dm644 -t "$pkgdir/usr/share/applications/" \
+		"build/share/applications/$pkgname.desktop"
+
+	install -d "$pkgdir/usr/share/icons/hicolor/scalable/apps"
+	ln -s "/usr/share/$pkgname/$pkgname.svg" \
+		"$pkgdir/usr/share/icons/hicolor/scalable/apps/"
 }

--- a/typecatcher/PKGBUILD
+++ b/typecatcher/PKGBUILD
@@ -1,4 +1,5 @@
 # Maintainer: Caleb Maclennan <caleb@alerque.com>
+# Contributor: Mark Wagie <mark.wagie@tutanota.com>
 # Contributor: Marcos Heredia <chelqo@gmail.com>
 # Contributor: Filip Kemuel Dam Bartholdy <filip_kemuel@yahoo.dk>
 


### PR DESCRIPTION
Re: My AUR page comment: https://aur.archlinux.org/packages/typecatcher/#comment-845045

The GPL3 license is already installed in `/usr/share/licenses/common`, no need to install it twice.