### PR TITLE
upgpkg: brave 1.46.144-2

### DIFF
--- a/brave/.SRCINFO
+++ b/brave/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = brave
 	pkgdesc = A web browser that stops ads and trackers by default
-	pkgver = 1.46.140
+	pkgver = 1.46.144
 	pkgrel = 1
 	url = https://www.brave.com/download
 	arch = x86_64
@@ -21,6 +21,7 @@ pkgbase = brave
 	makedepends = ninja
 	makedepends = npm
 	makedepends = pipewire
+	makedepends = qt5-base
 	makedepends = python-protobuf
 	depends = alsa-lib
 	depends = dbus
@@ -53,6 +54,7 @@ pkgbase = brave
 	depends = opus
 	depends = harfbuzz
 	depends = re2
+	depends = libavif
 	depends = jsoncpp
 	depends = libxslt
 	depends = libpng
@@ -60,14 +62,16 @@ pkgbase = brave
 	optdepends = pipewire: WebRTC desktop sharing under Wayland
 	optdepends = kdialog: support for native dialogs in Plasma
 	optdepends = org.freedesktop.secrets: password storage backend
-	source = brave-browser::git+https://github.com/brave/brave-browser.git#tag=v1.46.140
-	source = brave::git+https://github.com/brave/brave-core.git#tag=v1.46.140
-	source = chromium::git+https://chromium.googlesource.com/chromium/src.git#tag=108.0.5359.99
+	optdepends = qt5-base: enable Qt5 with --enable-features=AllowQt
+	source = brave-browser::git+https://github.com/brave/brave-browser.git#tag=v1.46.144
+	source = brave::git+https://github.com/brave/brave-core.git#tag=v1.46.144
+	source = chromium::git+https://github.com/chromium/chromium.git#tag=108.0.5359.128
 	source = depot_tools::git+https://chromium.googlesource.com/chromium/tools/depot_tools.git
 	source = https://github.com/foutrelis/chromium-launcher/archive/refs/tags/v8/chromium-launcher-8.tar.gz
 	source = https://github.com/stha09/chromium-patches/releases/download/chromium-108-patchset-2/chromium-108-patchset-2.tar.xz
 	source = https://gitlab.com/hadogenes/brave-patches/-/archive/brave-1.28-patches-1/brave-patches-brave-1.28-patches-1.zip
 	source = chromium-launcher-electron-app.patch
+	source = chromium-launcher-vendor.patch
 	source = system-rust-utils.patch
 	source = brave-1.43-bat-native-ads-hash_vectorizer_fix-cstring.patch
 	source = brave-1.43-bat-native-ads-vector_data_fix-cmath.patch
@@ -91,6 +95,7 @@ pkgbase = brave
 	sha256sums = 40ef8af65e78901bb8554eddbbb5ebc55c0b8e7927f6ca51b2a353d1c7c50652
 	sha256sums = c63c8eeac709293991418a09ac7d8c0adde10c151495876794e025bd2b0fb8fe
 	sha256sums = 9235485adc4acbfaf303605f4428a6995a7b0b3b5a95181b185afbcb9f1f6ae5
+	sha256sums = 404bf09df39310a1e374c5e7eb9c7311239798adf4e8cd85b7ff04fc79647f88
 	sha256sums = f4345b63200a8bcf00876fa2f6eba99c49c97af1b6253b159072fbfad8fefeef
 	sha256sums = a4ed0ad8f4931bae08c42a20266b8e2f934f21811fe0892960798f14a1fcfd0b
 	sha256sums = 5c1e562b25d4fe614f3a77e00accc53001541b7b3f308fb7512cce1138878d7e

--- a/brave/PKGBUILD
+++ b/brave/PKGBUILD
@@ -28,7 +28,7 @@
 : "${COMPONENT:=4}"
 
 pkgname=brave
-pkgver=1.46.140
+pkgver=1.46.144
 pkgrel=1
 pkgdesc='A web browser that stops ads and trackers by default'
 arch=(x86_64)
@@ -63,11 +63,13 @@ makedepends=(cargo-audit
              ninja
              npm
              pipewire
+             qt5-base
              python-protobuf)
 optdepends=('pipewire: WebRTC desktop sharing under Wayland'
             'kdialog: support for native dialogs in Plasma'
-            'org.freedesktop.secrets: password storage backend')
-_chromium_ver=108.0.5359.99
+            'org.freedesktop.secrets: password storage backend'
+            'qt5-base: enable Qt5 with --enable-features=AllowQt')
+_chromium_ver=108.0.5359.128
 _gcc_patchset=2
 _patchset_name="chromium-${_chromium_ver%%.*}-patchset-$_gcc_patchset"
 _launcher_ver=8
@@ -76,12 +78,13 @@ _brave_patchset="1"
 _brave_patchset_name="brave-$_brave_base_ver-patches-$_brave_patchset"
 source=("brave-browser::git+https://github.com/brave/brave-browser.git#tag=v$pkgver"
         "brave::git+https://github.com/brave/brave-core.git#tag=v$pkgver"
-        "chromium::git+https://chromium.googlesource.com/chromium/src.git#tag=$_chromium_ver"
+        "chromium::git+https://github.com/chromium/chromium.git#tag=$_chromium_ver"
         'depot_tools::git+https://chromium.googlesource.com/chromium/tools/depot_tools.git'
         "https://github.com/foutrelis/chromium-launcher/archive/refs/tags/v$_launcher_ver/chromium-launcher-$_launcher_ver.tar.gz"
         "https://github.com/stha09/chromium-patches/releases/download/$_patchset_name/$_patchset_name.tar.xz"
         "https://gitlab.com/hadogenes/brave-patches/-/archive/$_brave_patchset_name/brave-patches-$_brave_patchset_name.zip"
         chromium-launcher-electron-app.patch
+        chromium-launcher-vendor.patch
         system-rust-utils.patch
         brave-1.43-bat-native-ads-hash_vectorizer_fix-cstring.patch
         brave-1.43-bat-native-ads-vector_data_fix-cmath.patch
@@ -109,6 +112,7 @@ sha256sums=('SKIP'
             '40ef8af65e78901bb8554eddbbb5ebc55c0b8e7927f6ca51b2a353d1c7c50652'
             'c63c8eeac709293991418a09ac7d8c0adde10c151495876794e025bd2b0fb8fe'
             '9235485adc4acbfaf303605f4428a6995a7b0b3b5a95181b185afbcb9f1f6ae5'
+            '404bf09df39310a1e374c5e7eb9c7311239798adf4e8cd85b7ff04fc79647f88'
             'f4345b63200a8bcf00876fa2f6eba99c49c97af1b6253b159072fbfad8fefeef'
             'a4ed0ad8f4931bae08c42a20266b8e2f934f21811fe0892960798f14a1fcfd0b'
             '5c1e562b25d4fe614f3a77e00accc53001541b7b3f308fb7512cce1138878d7e'
@@ -138,7 +142,7 @@ declare -gA _system_libs=(
     [icu]=icu
     [jsoncpp]=jsoncpp
     [libaom]=aom
-    #[libavif]=libavif  # needs https://github.com/AOMediaCodec/libavif/commit/d22d4de94120
+    [libavif]=libavif
     [libdrm]=
     [libjpeg]=libjpeg
     [libpng]=libpng
@@ -160,9 +164,9 @@ for _dep in "${_system_libs[@]}"; do
 done
 
 prepare() {
-
   cd chromium-launcher-$_launcher_ver
   patch -Np1 -i ../chromium-launcher-electron-app.patch
+  patch -Np1 -i ../chromium-launcher-vendor.patch
 
   cd ../brave-browser
 
@@ -248,14 +252,9 @@ prepare() {
   patch -Np1 -i "${srcdir}/use-oauth2-client-switches-as-default.patch"
 
   # Upstream fixes
-  patch -Np1 -i "${srcdir}/unbundle-jsoncpp-avoid-CFI-faults-with-is_cfi-true.patch"
   patch -Np1 -i "${srcdir}/re-fix-TFLite-build-error-on-linux-with-system-zlib.patch"
   patch -Np1 -i "${srcdir}/chromium-icu72.patch"
   patch -Np1 -d v8 <"${srcdir}/v8-enhance-Date-parser-to-take-Unicode-SPACE.patch"
-
-  # Revert kGlobalMediaControlsCastStartStop enabled by default
-  # https://crbug.com/1314342
-  patch -Rp1 -F3 -i "${srcdir}/REVERT-enable-GlobalMediaControlsCastStartStop.patch"
 
   # Revert ffmpeg roll requiring new channel layout API support
   # https://crbug.com/1325301
@@ -263,15 +262,15 @@ prepare() {
   # Revert switch from AVFrame::pkt_duration to AVFrame::duration
   patch -Rp1 -i "${srcdir}/REVERT-roll-src-third_party-ffmpeg-m106.patch"
 
+  # Disable kGlobalMediaControlsCastStartStop by default
+  # https://crbug.com/1314342
+  patch -Np1 -i "${srcdir}/disable-GlobalMediaControlsCastStartStop.patch"
+
   # https://crbug.com/angleproject/7582
   patch -Np0 -i "${srcdir}/angle-wayland-include-protocol.patch"
 
   # Fixes for building with libstdc++ instead of libc++
   patch -Np1 -i "${srcdir}/patches/chromium-103-VirtualCursor-std-layout.patch"
-  patch -Np1 -i "${srcdir}/patches/chromium-107-compiler.patch"
-
-  # Sysroot usage in autocxx for Rust
-  patch -Np1 -i "${srcdir}/rust-autocxx-use_sysroot.patch"
 
   # Hacky patching
   sed -e 's/\(enable_distro_version_check =\) true/\1 false/g' -i chrome/installer/linux/BUILD.gn
@@ -375,9 +374,8 @@ build() {
       'rtc_use_pipewire=true'
       'link_pulseaudio=true'
       'use_gnome_keyring=false'
-      'use_qt=false' # look into enabling this for M108
       'use_sysroot=false'
-      'use_system_libwayland_server=true'
+      'use_system_libwayland=true'
       'use_system_wayland_scanner=true'
       'use_custom_libcxx=false'
       'enable_hangout_services_extension=true'
@@ -508,6 +506,7 @@ package() {
     chrome_100_percent.pak
     chrome_200_percent.pak
     chrome_crashpad_handler
+    libqt5_shim.so
     resources.pak
     v8_context_snapshot.bin
 

--- a/brave/chromium-launcher-vendor.patch
+++ b/brave/chromium-launcher-vendor.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 92f28a1..46cb745 100644
+--- a/Makefile
++++ b/Makefile
+@@ -4,7 +4,7 @@ CHROMIUM_SUFFIX  =
+ CHROMIUM_APP     = Chromium
+ CHROMIUM_NAME    = chromium$(CHROMIUM_SUFFIX)
+ CHROMIUM_BINARY  = /usr/lib/$(CHROMIUM_NAME)/$(CHROMIUM_NAME)
+-CHROMIUM_VENDOR  = $(shell . /etc/os-release; echo $$NAME)
++CHROMIUM_VENDOR  = stable
+ 
+ override CFLAGS += $(shell pkg-config --cflags glib-2.0)
+ override LDLIBS += $(shell pkg-config --libs glib-2.0)


### PR DESCRIPTION
### Changelog
* Update `brave` version to 1.46.144
* Update `chromium` version to 108.0.5359.128
* Sync patches from official Arch `chromium` build
* Patched launcher for CHROME_VERSION_EXTRA. Brave release is now _stable_.

Note that this update does not solve the potential race condition when building package, meaning it's hard to build in a clean root. You might prefer building it with AUR helpers. 