### PR TITLE
upgpkg: brave 1.49.120-1

### DIFF
--- a/brave/.SRCINFO
+++ b/brave/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = brave
 	pkgdesc = Web browser that blocks ads and trackers by default
-	pkgver = 1.48.171
+	pkgver = 1.49.120
 	pkgrel = 1
 	url = https://www.brave.com/download
 	arch = x86_64
@@ -66,12 +66,12 @@ pkgbase = brave
 	optdepends = org.freedesktop.secrets: password storage backend on GNOME / Xfce
 	optdepends = kwallet: support for storing passwords in KWallet on Plasma
 	options = !lto
-	source = brave-browser::git+https://github.com/brave/brave-browser.git#tag=v1.48.171
-	source = brave::git+https://github.com/brave/brave-core.git#tag=v1.48.171
-	source = chromium::git+https://chromium.googlesource.com/chromium/src.git#tag=110.0.5481.177
+	source = brave-browser::git+https://github.com/brave/brave-browser.git#tag=v1.49.120
+	source = brave::git+https://github.com/brave/brave-core.git#tag=v1.49.120
+	source = chromium::git+https://chromium.googlesource.com/chromium/src.git#tag=111.0.5563.64
 	source = depot_tools::git+https://chromium.googlesource.com/chromium/tools/depot_tools.git
 	source = https://github.com/foutrelis/chromium-launcher/archive/refs/tags/v8/chromium-launcher-8.tar.gz
-	source = https://github.com/stha09/chromium-patches/releases/download/chromium-110-patchset-4/chromium-110-patchset-4.tar.xz
+	source = https://github.com/stha09/chromium-patches/releases/download/chromium-111-patchset-2/chromium-111-patchset-2.tar.xz
 	source = chromium-launcher-electron-app.patch
 	source = chromium-launcher-vendor.patch
 	source = system-rust-utils.patch
@@ -83,18 +83,18 @@ pkgbase = brave
 	source = brave-1.43-debounce-debounce_navigation_throttle_fix.patch
 	source = brave-1.43-ntp_background_images-std-size_t.patch
 	source = brave-1.48-partitioned_host_state_map-cstring.patch
-	source = https://raw.githubusercontent.com/archlinux/svntogit-packages/4e362eccaf5b0391053136a28ec0afb6a04d9b09/trunk/fix-the-way-to-handle-codecs-in-the-system-icu.patch
-	source = https://raw.githubusercontent.com/archlinux/svntogit-packages/4e362eccaf5b0391053136a28ec0afb6a04d9b09/trunk/v8-move-the-Stack-object-from-ThreadLocalTop.patch
-	source = https://raw.githubusercontent.com/archlinux/svntogit-packages/4e362eccaf5b0391053136a28ec0afb6a04d9b09/trunk/REVERT-roll-src-third_party-ffmpeg-m102.patch
-	source = https://raw.githubusercontent.com/archlinux/svntogit-packages/4e362eccaf5b0391053136a28ec0afb6a04d9b09/trunk/REVERT-roll-src-third_party-ffmpeg-m106.patch
-	source = https://raw.githubusercontent.com/archlinux/svntogit-packages/4e362eccaf5b0391053136a28ec0afb6a04d9b09/trunk/disable-GlobalMediaControlsCastStartStop.patch
-	source = https://raw.githubusercontent.com/archlinux/svntogit-packages/4e362eccaf5b0391053136a28ec0afb6a04d9b09/trunk/use-oauth2-client-switches-as-default.patch
+	source = brave-1.49-brave_wallet-hd_key-vector_fix.patch
+	source = https://raw.githubusercontent.com/archlinux/svntogit-packages/d1f67365bf7e2076454823ed99602c8e7c9b9287/trunk/sql-relax-constraints-on-VirtualCursor-layout.patch
+	source = https://raw.githubusercontent.com/archlinux/svntogit-packages/d1f67365bf7e2076454823ed99602c8e7c9b9287/trunk/REVERT-roll-src-third_party-ffmpeg-m102.patch
+	source = https://raw.githubusercontent.com/archlinux/svntogit-packages/d1f67365bf7e2076454823ed99602c8e7c9b9287/trunk/REVERT-roll-src-third_party-ffmpeg-m106.patch
+	source = https://raw.githubusercontent.com/archlinux/svntogit-packages/d1f67365bf7e2076454823ed99602c8e7c9b9287/trunk/disable-GlobalMediaControlsCastStartStop.patch
+	source = https://raw.githubusercontent.com/archlinux/svntogit-packages/d1f67365bf7e2076454823ed99602c8e7c9b9287/trunk/use-oauth2-client-switches-as-default.patch
 	sha256sums = SKIP
 	sha256sums = SKIP
 	sha256sums = SKIP
 	sha256sums = SKIP
 	sha256sums = 213e50f48b67feb4441078d50b0fd431df34323be15be97c55302d3fdac4483a
-	sha256sums = 8c7f93037cc236024cc8be815b2c2bd84f6dc9e32685299e31d4c6c42efde8b7
+	sha256sums = a016588340f1559198e4ce61c6e91c48cf863600f415cb5c46322de7e1f77909
 	sha256sums = 9235485adc4acbfaf303605f4428a6995a7b0b3b5a95181b185afbcb9f1f6ae5
 	sha256sums = 404bf09df39310a1e374c5e7eb9c7311239798adf4e8cd85b7ff04fc79647f88
 	sha256sums = a8b119138c7157a71f2d1240bea5a2af9593d6b774586f5cc337b344cd9a18b8
@@ -106,8 +106,8 @@ pkgbase = brave
 	sha256sums = 30a6a9ca2a6dd965cb2d9f02639079130948bf45d483f0c629f2cf8394a1c22f
 	sha256sums = ea0cd714ccaa839baf7c71e9077264016aa19415600f16b77d5398fd49f5a70b
 	sha256sums = 3864fcb12aaec849fd0e5423c9c5dfb1fdd7805e298a52125776bb24abe71e3c
-	sha256sums = a5d5c532b0b059895bc13aaaa600d21770eab2afa726421b78cb597a78a3c7e3
-	sha256sums = 49c3e599366909ddac6a50fa6f9420e01a7c0ffd029a20567a41d741a15ec9f7
+	sha256sums = f55438b4d5fd3c14e3e6c16383e6305ec52818c1fc9438d0d40ff72d157504a3
+	sha256sums = e66be069d932fe18811e789c57b96249b7250257ff91a3d82d15e2a7283891b7
 	sha256sums = 30df59a9e2d95dcb720357ec4a83d9be51e59cc5551365da4c0073e68ccdec44
 	sha256sums = 4c12d31d020799d31355faa7d1fe2a5a807f7458e7f0c374adf55edb37032152
 	sha256sums = 7f3b1b22d6a271431c1f9fc92b6eb49c6d80b8b3f868bdee07a6a1a16630a302

--- a/brave/brave-1.49-brave_wallet-hd_key-vector_fix.patch
+++ b/brave/brave-1.49-brave_wallet-hd_key-vector_fix.patch
@@ -1,0 +1,22 @@
+diff --git a/brave/components/brave_wallet/browser/internal/hd_key.cc b/brave/components/brave_wallet/browser/internal/hd_key.cc
+index e42c4094ab..42670dce00 100644
+--- a/brave/components/brave_wallet/browser/internal/hd_key.cc
++++ b/brave/components/brave_wallet/browser/internal/hd_key.cc
+@@ -546,7 +546,7 @@ std::unique_ptr<HDKeyBase> HDKey::DeriveChildFromPath(const std::string& path) {
+       hd_key->SetPrivateKey(private_key_);
+     else
+       hd_key->SetPublicKey(public_key_);
+-    hd_key->chain_code_ = chain_code_;
++    hd_key->chain_code_.assign(chain_code_.begin(), chain_code_.end());
+     return std::unique_ptr<HDKeyBase>{hd_key.release()};
+   }
+   std::vector<std::string> entries =
+@@ -565,7 +565,7 @@ std::unique_ptr<HDKeyBase> HDKey::DeriveChildFromPath(const std::string& path) {
+         hd_key->SetPrivateKey(private_key_);
+       else
+         hd_key->SetPublicKey(public_key_);
+-      hd_key->chain_code_ = chain_code_;
++      hd_key->chain_code_.assign(chain_code_.begin(), chain_code_.end());
+       continue;
+     }
+     bool is_hardened = entry.length() > 1 && entry.back() == '\'';


### PR DESCRIPTION
### Changelog
* Update `brave` version to 1.49.120
* Update `chromium` version to 111.0.5563.64
* Update `SRCINFO`
* Updated patches for the latest Brave release

Sorry for taking so long for this update. Apparently the Brave team refactored some part of their built-in wallet and caused compatibility issues between `libstdc++` (used by Arch's `chromium` build) and Brave's default toolchain (`libc++`). A new patch was added as a workaround. Not sure if this patch would lead to functional changes, further reviews from the Brave team are probably needed. 