### PR TITLE
Update brave to v1.52.126

### DIFF
--- a/brave/.SRCINFO
+++ b/brave/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = brave
 	pkgdesc = Web browser that blocks ads and trackers by default
-	pkgver = 1.52.122
+	pkgver = 1.52.126
 	pkgrel = 1
 	url = https://www.brave.com/download
 	arch = x86_64
@@ -65,9 +65,9 @@ pkgbase = brave
 	optdepends = org.freedesktop.secrets: password storage backend on GNOME / Xfce
 	optdepends = kwallet: support for storing passwords in KWallet on Plasma
 	options = !lto
-	source = brave-browser::git+https://github.com/brave/brave-browser.git#tag=v1.52.122
-	source = brave::git+https://github.com/brave/brave-core.git#tag=v1.52.122
-	source = chromium-mirror::git+https://github.com/chromium/chromium.git#tag=114.0.5735.110
+	source = brave-browser::git+https://github.com/brave/brave-browser.git#tag=v1.52.126
+	source = brave::git+https://github.com/brave/brave-core.git#tag=v1.52.126
+	source = chromium-mirror::git+https://github.com/chromium/chromium.git#tag=114.0.5735.133
 	source = depot_tools::git+https://chromium.googlesource.com/chromium/tools/depot_tools.git
 	source = https://github.com/foutrelis/chromium-launcher/archive/refs/tags/v8/chromium-launcher-8.tar.gz
 	source = chromium-launcher-electron-app.patch

--- a/brave/PKGBUILD
+++ b/brave/PKGBUILD
@@ -28,7 +28,7 @@
 : "${COMPONENT:=4}"
 
 pkgname=brave
-pkgver=1.52.122
+pkgver=1.52.126
 pkgrel=1
 pkgdesc='Web browser that blocks ads and trackers by default'
 arch=(x86_64)
@@ -46,7 +46,7 @@ optdepends=('pipewire: WebRTC desktop sharing under Wayland'
             'org.freedesktop.secrets: password storage backend on GNOME / Xfce'
             'kwallet: support for storing passwords in KWallet on Plasma')
 options=('!lto') # Chromium adds its own flags for ThinLTO
-_chromium_ver=114.0.5735.110
+_chromium_ver=114.0.5735.133
 _launcher_ver=8
 source=("brave-browser::git+https://github.com/brave/brave-browser.git#tag=v$pkgver"
         "brave::git+https://github.com/brave/brave-core.git#tag=v$pkgver"


### PR DESCRIPTION
This PR updates `brave` to `1.52.122`.

Changes:
- Sync with `extra/chromium` at `114.0.5735.133`.
