### PR TITLE
gitui-git: fix license dir and pkgver(); disable LTO

### DIFF
--- a/gitui-git/.SRCINFO
+++ b/gitui-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = gitui-git
 	pkgdesc = Blazing fast terminal-ui for git written in Rust
-	pkgver = 0.17.1.r23.gd359fabe
+	pkgver = 0.23.0.r17.gc1e20958
 	pkgrel = 1
 	url = https://github.com/extrawurst/gitui
 	arch = x86_64
@@ -14,8 +14,9 @@ pkgbase = gitui-git
 	depends = libgit2.so
 	depends = libxcb
 	depends = zlib
-	provides = gitui=0.17.1.r23.gd359fabe
+	provides = gitui=0.23.0.r17.gc1e20958
 	conflicts = gitui
+	options = !lto
 	source = gitui-git::git+https://github.com/extrawurst/gitui.git
 	sha256sums = SKIP
 

--- a/gitui-git/PKGBUILD
+++ b/gitui-git/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Caleb Maclennan <caleb@alerque.com>
 
 pkgname=gitui-git
-pkgver=0.17.1.r23.gd359fabe
+pkgver=0.23.0.r17.gc1e20958
 pkgrel=1
 pkgdesc='Blazing fast terminal-ui for git written in Rust'
 url='https://github.com/extrawurst/gitui'
@@ -14,6 +14,7 @@ provides=("gitui=$pkgver")
 conflicts=('gitui')
 source=("$pkgname::git+$url.git")
 sha256sums=('SKIP')
+options=(!lto)
 
 prepare() {
   cd "${pkgname}"
@@ -22,7 +23,7 @@ prepare() {
 
 pkgver() {
   cd "${pkgname}"
-  git describe --long | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g'
+  git describe --long --tags | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 build() {
@@ -44,5 +45,5 @@ package() {
   cd "$pkgname"
   install -Dm0755 -t "$pkgdir/usr/bin/" "target/release/${pkgname%-git}"
   install -Dm0644 -t "$pkgdir/usr/share/doc/$pkgname" {KEY_CONFIG,README,THEMES}.md
-  install -Dm0644 -t "${pkgdir}/usr/share/licenses/${pkgname%-git}" LICENSE.md
+  install -Dm0644 -t "$pkgdir/usr/share/licenses/$pkgname" LICENSE.md
 }


### PR DESCRIPTION
* License should be installed to `/usr/share/licenses/$pkgname/` as per guidelines
* `pkgver()` needs `git describe --long --tags` to generate correct version, due to recent unannotated release tags (without --tags it reports as `0.19.0.r418.gc1e20958`)
* Needs LTO off to prevent following error during clean chroot build: https://gist.githubusercontent.com/eclairevoyant/5bceeb72b7d16f8327202229b0954e4c/raw/1b8828c0870e4a8cd74d2b9e9ba69236e47f90c7/error%2520log