### PR TITLE
nix-git: fix build errors; minor improvements

### DIFF
--- a/nix-git/.SRCINFO
+++ b/nix-git/.SRCINFO
@@ -1,11 +1,11 @@
 pkgbase = nix-git
 	pkgdesc = A purely functional package manager
-	pkgver = 2.2.r7982.g60f06a1
+	pkgver = 2.2.r8050.ga5c88f8
 	pkgrel = 1
 	url = https://nixos.org/nix
 	arch = x86_64
 	arch = i686
-	license = LGPL2
+	license = LGPL2.1
 	makedepends = autoconf-archive
 	makedepends = aws-crt-cpp
 	makedepends = aws-sdk-cpp
@@ -62,9 +62,10 @@ pkgname = nix-git
 	depends = nix-busybox
 	depends = openssl
 	depends = sqlite
-	provides = nix=2.2.r7982.g60f06a1
+	provides = nix=2.2.r8050.ga5c88f8
 	conflicts = nix
 	backup = etc/nix/nix.conf
 
 pkgname = nix-docs-git
 	pkgdesc = A purely functional package manager (documentation)
+	arch = any

--- a/nix-git/PKGBUILD
+++ b/nix-git/PKGBUILD
@@ -1,4 +1,5 @@
 # Maintainer: Caleb Maclennan <caleb@alerque.com>
+# Contributor: éclairevoyant
 # Contributor: George Rawlinson <grawlinson@archlinux.org>
 # Contributor: Andy Weidenbaum <archbaum@gmail.com>
 # Contributor: Vlad M. <vlad@archlinux.net>
@@ -9,12 +10,12 @@
 pkgbase=nix-git
 pkgname=(nix-git nix-docs-git)
 _pkgname=${pkgbase%-git}
-pkgver=2.2.r7982.g60f06a1
+pkgver=2.2.r8050.ga5c88f8
 pkgrel=1
 pkgdesc='A purely functional package manager'
 arch=(x86_64 i686)
 url="https://nixos.org/$_pkgname"
-license=(LGPL2)
+license=(LGPL2.1)
 makedepends=(autoconf-archive
              aws-crt-cpp
              aws-sdk-cpp
@@ -66,14 +67,12 @@ pkgver() {
 
 build() {
 	cd "$_pkgname"
-	CXXFLAGS='-D_GLIBCXX_USE_CXX11_ABI=0' \
 	./configure \
 		--prefix=/usr \
 		--libexecdir="/usr/lib/$_pkgname" \
 		--sysconfdir=/etc \
 		--localstatedir=/nix/var \
 		--with-sandbox-shell=/usr/lib/nix/busybox \
-		--enable-static=rapidcheck \
 		--enable-gc \
 		--enable-lto
 	make
@@ -118,6 +117,7 @@ package_nix-git() {
 
 package_nix-docs-git() {
 	pkgdesc+=" (documentation)"
+	arch=(any)
 	cd "$_pkgname"
 	install -vd "$pkgdir/usr/share/doc"
 	mv nix-docs/nix "$pkgdir/usr/share/doc"


### PR DESCRIPTION
* drop the `--enable-static` flag as the configure script doesn't recognise it (`configure: WARNING: unrecognized options: --enable-static` appear in the logs)
* don't use `_GLIBCXX_USE_CXX11_ABI` as it breaks clean chroot build (see output below)
* fix license identifier
* docs package should have `arch=(any)`

<details>
  <summary>Build log (excerpt) when _GLIBCXX_USE_CXX11_ABI is set to 0</summary>
  
  ```
  LD     src/libutil/tests/libnixutil-tests
  LD     src/libstore/libnixstore.so
/usr/bin/ld: /tmp/cceFekHS.ltrans0.ltrans.o: in function `nix::CanonPath_within_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/canon-path.cc:110: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/canon-path.cc:113: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/canon-path.cc:111: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/canon-path.cc:112: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/canon-path.cc:114: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans0.ltrans.o:/build/nix-git/src/nix/src/libutil/tests/canon-path.cc:115: more undefined references to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)' follow
/usr/bin/ld: /tmp/cceFekHS.ltrans0.ltrans.o: in function `std::string testing::PrintToString<char const*>(char const* const&)':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans0.ltrans.o: in function `std::string testing::PrintToString<std::basic_string_view<char, std::char_traits<char> > >(std::basic_string_view<char, std::char_traits<char> > const&)':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans0.ltrans.o: in function `nix::CanonPath_allowed_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/canon-path.cc:149: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/canon-path.cc:136: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/canon-path.cc:135: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/canon-path.cc:137: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/canon-path.cc:138: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans0.ltrans.o:/build/nix-git/src/nix/src/libutil/tests/canon-path.cc:139: more undefined references to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)' follow
/usr/bin/ld: /tmp/cceFekHS.ltrans0.ltrans.o: in function `std::string testing::PrintToString<std::string>(std::string const&)':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans0.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<std::string, char [21]>(char const*, char const*, std::string const&, char const (&) [21])':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans0.ltrans.o: in function `std::string testing::PrintToString<std::optional<std::basic_string_view<char, std::char_traits<char> > > >(std::optional<std::basic_string_view<char, std::char_traits<char> > > const&)':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans0.ltrans.o: in function `std::string testing::PrintToString<std::vector<std::basic_string_view<char, std::char_traits<char> >, std::allocator<std::basic_string_view<char, std::char_traits<char> > > > >(std::vector<std::basic_string_view<char, std::char_traits<char> >, std::allocator<std::basic_string_view<char, std::char_traits<char> > > > const&)':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans0.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<std::basic_string_view<char, std::char_traits<char> >, char [8]>(char const*, char const*, std::basic_string_view<char, std::char_traits<char> > const&, char const (&) [8])':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans0.ltrans.o: in function `nix::CanonPath_basic_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/canon-path.cc:14: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans1.ltrans.o: in function `std::string testing::PrintToString<std::set<std::string, std::less<std::string>, std::allocator<std::string> > >(std::set<std::string, std::less<std::string>, std::allocator<std::string> > const&)':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans1.ltrans.o: in function `nix::ChunkedVector_ForEach_Test::TestBody()':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans1.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQFailure<int, int>(char const*, char const*, int const&, int const&)':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans1.ltrans.o: in function `nix::closure_correctClosure_Test::TestBody()':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans1.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<std::string, char const*>(char const*, char const*, std::string const&, char const* const&)':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans2.ltrans.o: in function `nix::Config_addSetting_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/config.cc:91: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/config.cc:93: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/config.cc:94: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans2.ltrans.o: in function `nix::Config_applyConfigEmpty_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/config.cc:241: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans2.ltrans.o: in function `nix::Config_applyConfigEmptyWithComment_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/config.cc:249: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans2.ltrans.o:/build/nix-git/src/nix/src/libutil/tests/config.cc:274: more undefined references to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)' follow
/usr/bin/ld: /tmp/cceFekHS.ltrans3.ltrans.o: in function `testing::AssertionResult& testing::AssertionResult::operator<< <char const*>(char const* const&)':
/usr/include/gtest/gtest-assertion-result.h:208: undefined reference to `testing::Message::GetString() const'
/usr/bin/ld: /tmp/cceFekHS.ltrans3.ltrans.o: in function `testing::AssertionResult& testing::AssertionResult::operator<< <char [3]>(char const (&) [3])':
/usr/include/gtest/gtest-assertion-result.h:208: undefined reference to `testing::Message::GetString() const'
/usr/bin/ld: /tmp/cceFekHS.ltrans3.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQFailure<bool, bool>(char const*, char const*, bool const&, bool const&)':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans4.ltrans.o: in function `std::string testing::PrintToString<std::optional<std::string> >(std::optional<std::string> const&)':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans4.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<std::optional<std::string>, char [15]>(char const*, char const*, std::optional<std::string> const&, char const (&) [15])':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans4.ltrans.o: in function `nix::GitLsRemote_parseSymrefLineWithReference_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/git.cc:9: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans4.ltrans.o: in function `nix::GitLsRemote_parseSymrefLineWithNoReference_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/git.cc:18: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans4.ltrans.o: in function `nix::GitLsRemote_parseSymrefLineWithNoReference_Test::TestBody()':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans4.ltrans.o: in function `nix::GitLsRemote_parseSymrefLineWithNoReference_Test::TestBody()':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans4.ltrans.o: in function `nix::GitLsRemote_parseObjectRefLine_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/git.cc:27: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans7.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQFailure<unsigned long, int>(char const*, char const*, unsigned long const&, int const&)':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans7.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<unsigned long, int>(char const*, char const*, unsigned long const&, int const&)':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans7.ltrans.o: in function `nix::Pool_badResourceIsNotReused_Test::TestBody()':
/usr/include/gtest/gtest-assertion-result.h:208: undefined reference to `testing::Message::GetString() const'
/usr/bin/ld: /usr/include/gtest/gtest-assertion-result.h:208: undefined reference to `testing::Message::GetString() const'
/usr/bin/ld: /tmp/cceFekHS.ltrans7.ltrans.o: in function `nix::LRUCache_overwriteOldestWhenCapacityIsReached_Test::TestBody()':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans8.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<std::string, std::string>(char const*, char const*, std::string const&, std::string const&)':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans8.ltrans.o: in function `testing::internal::ParameterizedTestSuiteInfo<nix::RewriteTest>::RegisterTests()':
/usr/include/gtest/internal/gtest-param-util.h:599: undefined reference to `testing::Message::GetString() const'
/usr/bin/ld: /usr/include/gtest/internal/gtest-param-util.h:613: undefined reference to `testing::internal::InsertSyntheticTestCase(std::string const&, testing::internal::CodeLocation, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans8.ltrans.o: in function `nix::gtest_referencesRewriteTest_EvalGenerateName_(testing::TestParamInfo<nix::RewriteParams> const&) [clone .lto_priv.0]':
/usr/include/gtest/internal/gtest-param-util.h:384: undefined reference to `testing::Message::GetString() const'
/usr/bin/ld: /tmp/cceFekHS.ltrans8.ltrans.o: in function `nix::gtest_LevenshteinDistanceLevenshteinDistanceTest_EvalGenerateName_(testing::TestParamInfo<nix::LevenshteinDistanceParam> const&) [clone .lto_priv.0]':
/usr/include/gtest/internal/gtest-param-util.h:384: undefined reference to `testing::Message::GetString() const'
/usr/bin/ld: /tmp/cceFekHS.ltrans8.ltrans.o: in function `nix::Suggestions_Trim_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/suggestions.cc:38: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans9.ltrans.o: in function `nix::hasPrefix_emptyStringHasNoPrefix_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/tests.cc:242: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans9.ltrans.o: in function `nix::hasPrefix_emptyStringIsAlwaysPrefix_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/tests.cc:246: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/tests.cc:247: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans9.ltrans.o: in function `nix::pathExists_rootExists_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/tests.cc:197: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans9.ltrans.o:/build/nix-git/src/nix/src/libutil/tests/tests.cc:201: more undefined references to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)' follow
/usr/bin/ld: /tmp/cceFekHS.ltrans9.ltrans.o: in function `testing::internal::ParameterizedTestSuiteInfo<nix::LevenshteinDistanceTest>::RegisterTests()':
/usr/include/gtest/internal/gtest-param-util.h:599: undefined reference to `testing::Message::GetString() const'
/usr/bin/ld: /usr/include/gtest/internal/gtest-param-util.h:613: undefined reference to `testing::internal::InsertSyntheticTestCase(std::string const&, testing::internal::CodeLocation, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans9.ltrans.o: in function `nix::canonPath_requiresAbsolutePath_Test::TestBody() [clone .cold]':
/build/nix-git/src/nix/src/libutil/tests/tests.cc:90: undefined reference to `testing::internal::DeathTest::Create(char const*, testing::Matcher<std::string const&>, char const*, int, testing::internal::DeathTest**)'
/usr/bin/ld: /tmp/cceFekHS.ltrans9.ltrans.o:/build/nix-git/src/nix/src/libutil/tests/tests.cc:90: undefined reference to `testing::internal::FormatFileLocation(char const*, int)'
/usr/bin/ld: /tmp/cceFekHS.ltrans10.ltrans.o: in function `nix::hasSuffix_emptyStringHasNoSuffix_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/tests.cc:259: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans10.ltrans.o: in function `nix::hasSuffix_trivialCase_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/tests.cc:263: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/tests.cc:264: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans10.ltrans.o: in function `nix::string2Float_emptyString_Test::TestBody()':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans10.ltrans.o: in function `nix::string2Int_emptyString_Test::TestBody()':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans11.ltrans.o: in function `void testing::internal::MatcherBase<std::string const&>::DescribeImpl<testing::internal::MatcherBase<std::string const&>::ValuePolicy<testing::MatcherInterface<std::string const&> const*, true> >(testing::internal::MatcherBase<std::string const&> const&, std::ostream*, bool)':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans11.ltrans.o: in function `nix::get_emptyContainer_Test::TestBody()':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans11.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<std::optional<double>, double>(char const*, char const*, std::optional<double> const&, double const&)':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans11.ltrans.o: in function `std::string testing::PrintToString<std::list<std::string, std::allocator<std::string> > >(std::list<std::string, std::allocator<std::string> > const&)':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans11.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQFailure<std::list<std::string, std::allocator<std::string> >, std::list<std::string, std::allocator<std::string> > >(char const*, char const*, std::list<std::string, std::allocator<std::string> > const&, std::list<std::string, std::allocator<std::string> > const&)':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans11.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<std::optional<int>, int>(char const*, char const*, std::optional<int> const&, int const&)':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans12.ltrans.o: in function `testing::PolymorphicMatcher<testing::internal::MatchesRegexMatcher>::MonomorphicImpl<std::string const&>::DescribeTo(std::ostream*) const':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans12.ltrans.o: in function `testing::PolymorphicMatcher<testing::internal::MatchesRegexMatcher>::MonomorphicImpl<std::string const&>::DescribeNegationTo(std::ostream*) const':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans13.ltrans.o: in function `nix::parseURL_parsedUrlsIsEqualToItself_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/url.cc:223: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans13.ltrans.o: in function `std::string testing::PrintToString<std::map<std::string, std::string, std::less<std::string>, std::allocator<std::pair<std::string const, std::string> > > >(std::map<std::string, std::string, std::less<std::string>, std::allocator<std::pair<std::string const, std::string> > > const&)':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/cceFekHS.ltrans13.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<std::map<std::string, std::string, std::less<std::string>, std::allocator<std::pair<std::string const, std::string> > >, std::map<std::string, std::string, std::less<std::string>, std::allocator<std::pair<std::string const, std::string> > > >(char const*, char const*, std::map<std::string, std::string, std::less<std::string>, std::allocator<std::pair<std::string const, std::string> > > const&, std::map<std::string, std::string, std::less<std::string>, std::allocator<std::pair<std::string const, std::string> > > const&)':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans14.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<nix::ParsedURL, nix::ParsedURL>(char const*, char const*, nix::ParsedURL const&, nix::ParsedURL const&) [clone .constprop.0]':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans14.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<unsigned long, int>(char const*, char const*, unsigned long const&, int const&) [clone .constprop.0]':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans14.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQFailure<nix::git::LsRemoteRefLine::Kind, nix::git::LsRemoteRefLine::Kind>(char const*, char const*, nix::git::LsRemoteRefLine::Kind const&, nix::git::LsRemoteRefLine::Kind const&) [clone .constprop.0]':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans14.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQFailure<nlohmann::json_abi_v3_11_2::basic_json<std::map, std::vector, std::string, bool, long, unsigned long, double, std::allocator, nlohmann::json_abi_v3_11_2::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > >, nlohmann::json_abi_v3_11_2::basic_json<std::map, std::vector, std::string, bool, long, unsigned long, double, std::allocator, nlohmann::json_abi_v3_11_2::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > > >(char const*, char const*, nlohmann::json_abi_v3_11_2::basic_json<std::map, std::vector, std::string, bool, long, unsigned long, double, std::allocator, nlohmann::json_abi_v3_11_2::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > > const&, nlohmann::json_abi_v3_11_2::basic_json<std::map, std::vector, std::string, bool, long, unsigned long, double, std::allocator, nlohmann::json_abi_v3_11_2::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > > const&) [clone .constprop.0]':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans15.ltrans.o:/usr/include/gtest/gtest.h:1359: more undefined references to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)' follow
/usr/bin/ld: /tmp/cceFekHS.ltrans15.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperNE<std::_Rb_tree_iterator<std::pair<std::string const, nix::AbstractConfig::SettingInfo> >, std::_Rb_tree_iterator<std::pair<std::string const, nix::AbstractConfig::SettingInfo> > >(char const*, char const*, std::_Rb_tree_iterator<std::pair<std::string const, nix::AbstractConfig::SettingInfo> > const&, std::_Rb_tree_iterator<std::pair<std::string const, nix::AbstractConfig::SettingInfo> > const&) [clone .constprop.0]':
/usr/include/gtest/gtest-assertion-result.h:208: undefined reference to `testing::Message::GetString() const'
/usr/bin/ld: /usr/include/gtest/gtest-assertion-result.h:208: undefined reference to `testing::Message::GetString() const'
/usr/bin/ld: /tmp/cceFekHS.ltrans15.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQFailure<int*, int const*>(char const*, char const*, int* const&, int const* const&) [clone .constprop.0]':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans15.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQFailure<unsigned int, int>(char const*, char const*, unsigned int const&, int const&) [clone .constprop.0]':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans15.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<std::vector<std::basic_string_view<char, std::char_traits<char> >, std::allocator<std::basic_string_view<char, std::char_traits<char> > > >, std::vector<std::basic_string_view<char, std::char_traits<char> >, std::allocator<std::basic_string_view<char, std::char_traits<char> > > > >(char const*, char const*, std::vector<std::basic_string_view<char, std::char_traits<char> >, std::allocator<std::basic_string_view<char, std::char_traits<char> > > > const&, std::vector<std::basic_string_view<char, std::char_traits<char> >, std::allocator<std::basic_string_view<char, std::char_traits<char> > > > const&) [clone .constprop.0]':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/cceFekHS.ltrans15.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<std::optional<std::basic_string_view<char, std::char_traits<char> > >, std::nullopt_t>(char const*, char const*, std::optional<std::basic_string_view<char, std::char_traits<char> > > const&, std::nullopt_t const&) [clone .constprop.0]':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
collect2: error: ld returned 1 exit status
make: *** [mk/lib.mk:119: src/libutil/tests/libnixutil-tests] Error 1
make: *** Waiting for unfinished jobs....
/usr/bin/ld: /tmp/ccODwMno.ltrans0.ltrans.o: in function `nix::CanonPath_within_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/canon-path.cc:110: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/canon-path.cc:113: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/canon-path.cc:111: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/canon-path.cc:112: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/canon-path.cc:114: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans0.ltrans.o:/build/nix-git/src/nix/src/libutil/tests/canon-path.cc:115: more undefined references to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)' follow
/usr/bin/ld: /tmp/ccODwMno.ltrans0.ltrans.o: in function `std::string testing::PrintToString<char const*>(char const* const&)':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans0.ltrans.o: in function `std::string testing::PrintToString<std::basic_string_view<char, std::char_traits<char> > >(std::basic_string_view<char, std::char_traits<char> > const&)':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans0.ltrans.o: in function `nix::CanonPath_allowed_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/canon-path.cc:149: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/canon-path.cc:136: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/canon-path.cc:135: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/canon-path.cc:137: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/canon-path.cc:138: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans0.ltrans.o:/build/nix-git/src/nix/src/libutil/tests/canon-path.cc:139: more undefined references to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)' follow
/usr/bin/ld: /tmp/ccODwMno.ltrans0.ltrans.o: in function `std::string testing::PrintToString<std::string>(std::string const&)':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans0.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<std::string, char [21]>(char const*, char const*, std::string const&, char const (&) [21])':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans0.ltrans.o: in function `std::string testing::PrintToString<std::optional<std::basic_string_view<char, std::char_traits<char> > > >(std::optional<std::basic_string_view<char, std::char_traits<char> > > const&)':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans0.ltrans.o: in function `std::string testing::PrintToString<std::vector<std::basic_string_view<char, std::char_traits<char> >, std::allocator<std::basic_string_view<char, std::char_traits<char> > > > >(std::vector<std::basic_string_view<char, std::char_traits<char> >, std::allocator<std::basic_string_view<char, std::char_traits<char> > > > const&)':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans0.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<std::basic_string_view<char, std::char_traits<char> >, char [8]>(char const*, char const*, std::basic_string_view<char, std::char_traits<char> > const&, char const (&) [8])':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans0.ltrans.o: in function `nix::CanonPath_basic_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/canon-path.cc:14: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans1.ltrans.o: in function `std::string testing::PrintToString<std::set<std::string, std::less<std::string>, std::allocator<std::string> > >(std::set<std::string, std::less<std::string>, std::allocator<std::string> > const&)':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans1.ltrans.o: in function `nix::ChunkedVector_ForEach_Test::TestBody()':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans1.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQFailure<int, int>(char const*, char const*, int const&, int const&)':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans1.ltrans.o: in function `nix::closure_correctClosure_Test::TestBody()':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans1.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<std::string, char const*>(char const*, char const*, std::string const&, char const* const&)':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans2.ltrans.o: in function `nix::Config_addSetting_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/config.cc:91: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/config.cc:93: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/config.cc:94: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans2.ltrans.o: in function `nix::Config_applyConfigEmpty_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/config.cc:241: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans2.ltrans.o: in function `nix::Config_applyConfigEmptyWithComment_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/config.cc:249: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans2.ltrans.o:/build/nix-git/src/nix/src/libutil/tests/config.cc:274: more undefined references to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)' follow
/usr/bin/ld: /tmp/ccODwMno.ltrans3.ltrans.o: in function `testing::AssertionResult& testing::AssertionResult::operator<< <char const*>(char const* const&)':
/usr/include/gtest/gtest-assertion-result.h:208: undefined reference to `testing::Message::GetString() const'
/usr/bin/ld: /tmp/ccODwMno.ltrans3.ltrans.o: in function `testing::AssertionResult& testing::AssertionResult::operator<< <char [3]>(char const (&) [3])':
/usr/include/gtest/gtest-assertion-result.h:208: undefined reference to `testing::Message::GetString() const'
/usr/bin/ld: /tmp/ccODwMno.ltrans3.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQFailure<bool, bool>(char const*, char const*, bool const&, bool const&)':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans4.ltrans.o: in function `rc::detail::Any::AnyImpl<unsigned char>::showType(std::ostream&) const':
/usr/include/rapidcheck/detail/ShowType.hpp:48: undefined reference to `rc::detail::demangle(char const*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans4.ltrans.o: in function `std::string testing::PrintToString<std::optional<std::string> >(std::optional<std::string> const&)':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans4.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<std::optional<std::string>, char [15]>(char const*, char const*, std::optional<std::string> const&, char const (&) [15])':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans4.ltrans.o: in function `nix::GitLsRemote_parseSymrefLineWithReference_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/git.cc:9: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans4.ltrans.o: in function `nix::GitLsRemote_parseSymrefLineWithNoReference_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/git.cc:18: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans4.ltrans.o: in function `nix::GitLsRemote_parseSymrefLineWithNoReference_Test::TestBody()':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans4.ltrans.o: in function `nix::GitLsRemote_parseSymrefLineWithNoReference_Test::TestBody()':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans4.ltrans.o: in function `nix::GitLsRemote_parseObjectRefLine_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/git.cc:27: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans7.ltrans.o: in function `nix::LRUCache_overwriteOldestWhenCapacityIsReached_Test::TestBody()':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans8.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQFailure<unsigned long, int>(char const*, char const*, unsigned long const&, int const&)':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans8.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<unsigned long, int>(char const*, char const*, unsigned long const&, int const&)':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans8.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<std::string, std::string>(char const*, char const*, std::string const&, std::string const&)':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans8.ltrans.o: in function `nix::Pool_badResourceIsNotReused_Test::TestBody()':
/usr/include/gtest/gtest-assertion-result.h:208: undefined reference to `testing::Message::GetString() const'
/usr/bin/ld: /usr/include/gtest/gtest-assertion-result.h:208: undefined reference to `testing::Message::GetString() const'
/usr/bin/ld: /tmp/ccODwMno.ltrans8.ltrans.o: in function `nix::gtest_referencesRewriteTest_EvalGenerateName_(testing::TestParamInfo<nix::RewriteParams> const&) [clone .lto_priv.0]':
/usr/include/gtest/internal/gtest-param-util.h:384: undefined reference to `testing::Message::GetString() const'
/usr/bin/ld: /tmp/ccODwMno.ltrans9.ltrans.o: in function `testing::internal::ParameterizedTestSuiteInfo<nix::RewriteTest>::RegisterTests()':
/usr/include/gtest/internal/gtest-param-util.h:599: undefined reference to `testing::Message::GetString() const'
/usr/bin/ld: /usr/include/gtest/internal/gtest-param-util.h:613: undefined reference to `testing::internal::InsertSyntheticTestCase(std::string const&, testing::internal::CodeLocation, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans9.ltrans.o: in function `nix::gtest_LevenshteinDistanceLevenshteinDistanceTest_EvalGenerateName_(testing::TestParamInfo<nix::LevenshteinDistanceParam> const&) [clone .lto_priv.0]':
/usr/include/gtest/internal/gtest-param-util.h:384: undefined reference to `testing::Message::GetString() const'
/usr/bin/ld: /tmp/ccODwMno.ltrans9.ltrans.o: in function `nix::Suggestions_Trim_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/suggestions.cc:38: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans10.ltrans.o: in function `nix::hasPrefix_emptyStringHasNoPrefix_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/tests.cc:242: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans10.ltrans.o: in function `nix::hasPrefix_emptyStringIsAlwaysPrefix_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/tests.cc:246: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /build/nix-git/src/nix/src/libutil/tests/tests.cc:247: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans10.ltrans.o: in function `nix::hasPrefix_trivialCase_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/tests.cc:251: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans10.ltrans.o:/build/nix-git/src/nix/src/libutil/tests/tests.cc:259: more undefined references to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)' follow
/usr/bin/ld: /tmp/ccODwMno.ltrans10.ltrans.o: in function `testing::internal::ParameterizedTestSuiteInfo<nix::LevenshteinDistanceTest>::RegisterTests()':
/usr/include/gtest/internal/gtest-param-util.h:599: undefined reference to `testing::Message::GetString() const'
/usr/bin/ld: /usr/include/gtest/internal/gtest-param-util.h:613: undefined reference to `testing::internal::InsertSyntheticTestCase(std::string const&, testing::internal::CodeLocation, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans10.ltrans.o: in function `nix::canonPath_requiresAbsolutePath_Test::TestBody() [clone .cold]':
/build/nix-git/src/nix/src/libutil/tests/tests.cc:90: undefined reference to `testing::internal::DeathTest::Create(char const*, testing::Matcher<std::string const&>, char const*, int, testing::internal::DeathTest**)'
/usr/bin/ld: /tmp/ccODwMno.ltrans10.ltrans.o:/build/nix-git/src/nix/src/libutil/tests/tests.cc:90: undefined reference to `testing::internal::FormatFileLocation(char const*, int)'
/usr/bin/ld: /tmp/ccODwMno.ltrans11.ltrans.o: in function `nix::string2Float_emptyString_Test::TestBody()':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans11.ltrans.o: in function `nix::string2Int_emptyString_Test::TestBody()':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans11.ltrans.o: in function `nix::get_emptyContainer_Test::TestBody()':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans12.ltrans.o: in function `void testing::internal::MatcherBase<std::string const&>::DescribeImpl<testing::internal::MatcherBase<std::string const&>::ValuePolicy<testing::MatcherInterface<std::string const&> const*, true> >(testing::internal::MatcherBase<std::string const&> const&, std::ostream*, bool)':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans12.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<std::optional<double>, double>(char const*, char const*, std::optional<double> const&, double const&)':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans12.ltrans.o: in function `std::string testing::PrintToString<std::list<std::string, std::allocator<std::string> > >(std::list<std::string, std::allocator<std::string> > const&)':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans12.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQFailure<std::list<std::string, std::allocator<std::string> >, std::list<std::string, std::allocator<std::string> > >(char const*, char const*, std::list<std::string, std::allocator<std::string> > const&, std::list<std::string, std::allocator<std::string> > const&)':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans12.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<std::optional<int>, int>(char const*, char const*, std::optional<int> const&, int const&)':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans13.ltrans.o: in function `testing::PolymorphicMatcher<testing::internal::MatchesRegexMatcher>::MonomorphicImpl<std::string const&>::DescribeTo(std::ostream*) const':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans13.ltrans.o: in function `testing::PolymorphicMatcher<testing::internal::MatchesRegexMatcher>::MonomorphicImpl<std::string const&>::DescribeNegationTo(std::ostream*) const':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans14.ltrans.o: in function `nix::parseURL_parsedUrlsIsEqualToItself_Test::TestBody()':
/build/nix-git/src/nix/src/libutil/tests/url.cc:223: undefined reference to `testing::internal::GetBoolAssertionFailureMessage(testing::AssertionResult const&, char const*, char const*, char const*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans14.ltrans.o: in function `std::string testing::PrintToString<std::map<std::string, std::string, std::less<std::string>, std::allocator<std::pair<std::string const, std::string> > > >(std::map<std::string, std::string, std::less<std::string>, std::allocator<std::pair<std::string const, std::string> > > const&)':
/usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /usr/include/gtest/gtest-printers.h:631: undefined reference to `testing::internal::PrintStringTo(std::string const&, std::ostream*)'
/usr/bin/ld: /tmp/ccODwMno.ltrans14.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<std::map<std::string, std::string, std::less<std::string>, std::allocator<std::pair<std::string const, std::string> > >, std::map<std::string, std::string, std::less<std::string>, std::allocator<std::pair<std::string const, std::string> > > >(char const*, char const*, std::map<std::string, std::string, std::less<std::string>, std::allocator<std::pair<std::string const, std::string> > > const&, std::map<std::string, std::string, std::less<std::string>, std::allocator<std::pair<std::string const, std::string> > > const&)':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans15.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<nix::ParsedURL, nix::ParsedURL>(char const*, char const*, nix::ParsedURL const&, nix::ParsedURL const&) [clone .constprop.0]':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans15.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<unsigned long, int>(char const*, char const*, unsigned long const&, int const&) [clone .constprop.0]':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans15.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQFailure<nix::git::LsRemoteRefLine::Kind, nix::git::LsRemoteRefLine::Kind>(char const*, char const*, nix::git::LsRemoteRefLine::Kind const&, nix::git::LsRemoteRefLine::Kind const&) [clone .constprop.0]':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans15.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQFailure<nlohmann::json_abi_v3_11_2::basic_json<std::map, std::vector, std::string, bool, long, unsigned long, double, std::allocator, nlohmann::json_abi_v3_11_2::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > >, nlohmann::json_abi_v3_11_2::basic_json<std::map, std::vector, std::string, bool, long, unsigned long, double, std::allocator, nlohmann::json_abi_v3_11_2::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > > >(char const*, char const*, nlohmann::json_abi_v3_11_2::basic_json<std::map, std::vector, std::string, bool, long, unsigned long, double, std::allocator, nlohmann::json_abi_v3_11_2::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > > const&, nlohmann::json_abi_v3_11_2::basic_json<std::map, std::vector, std::string, bool, long, unsigned long, double, std::allocator, nlohmann::json_abi_v3_11_2::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > > const&) [clone .constprop.0]':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans16.ltrans.o:/usr/include/gtest/gtest.h:1359: more undefined references to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)' follow
/usr/bin/ld: /tmp/ccODwMno.ltrans16.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperNE<std::_Rb_tree_iterator<std::pair<std::string const, nix::AbstractConfig::SettingInfo> >, std::_Rb_tree_iterator<std::pair<std::string const, nix::AbstractConfig::SettingInfo> > >(char const*, char const*, std::_Rb_tree_iterator<std::pair<std::string const, nix::AbstractConfig::SettingInfo> > const&, std::_Rb_tree_iterator<std::pair<std::string const, nix::AbstractConfig::SettingInfo> > const&) [clone .constprop.0]':
/usr/include/gtest/gtest-assertion-result.h:208: undefined reference to `testing::Message::GetString() const'
/usr/bin/ld: /usr/include/gtest/gtest-assertion-result.h:208: undefined reference to `testing::Message::GetString() const'
/usr/bin/ld: /tmp/ccODwMno.ltrans16.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQFailure<int*, int const*>(char const*, char const*, int* const&, int const* const&) [clone .constprop.0]':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans16.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQFailure<unsigned int, int>(char const*, char const*, unsigned int const&, int const&) [clone .constprop.0]':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans16.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<std::vector<std::basic_string_view<char, std::char_traits<char> >, std::allocator<std::basic_string_view<char, std::char_traits<char> > > >, std::vector<std::basic_string_view<char, std::char_traits<char> >, std::allocator<std::basic_string_view<char, std::char_traits<char> > > > >(char const*, char const*, std::vector<std::basic_string_view<char, std::char_traits<char> >, std::allocator<std::basic_string_view<char, std::char_traits<char> > > > const&, std::vector<std::basic_string_view<char, std::char_traits<char> >, std::allocator<std::basic_string_view<char, std::char_traits<char> > > > const&) [clone .constprop.0]':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
/usr/bin/ld: /tmp/ccODwMno.ltrans16.ltrans.o: in function `testing::AssertionResult testing::internal::CmpHelperEQ<std::optional<std::basic_string_view<char, std::char_traits<char> > >, std::nullopt_t>(char const*, char const*, std::optional<std::basic_string_view<char, std::char_traits<char> > > const&, std::nullopt_t const&) [clone .constprop.0]':
/usr/include/gtest/gtest.h:1359: undefined reference to `testing::internal::EqFailure(char const*, char const*, std::string const&, std::string const&, bool)'
collect2: error: ld returned 1 exit status
make: *** [mk/lib.mk:118: src/libutil/tests/libnixutil-tests.so] Error 1
/usr/bin/ld: /tmp/ccmaPUVG.ltrans35.ltrans.o: in function `Aws::Endpoint::DefaultEndpointProvider<Aws::Client::GenericClientConfiguration<true>, Aws::Endpoint::BuiltInParameters, Aws::Endpoint::ClientContextParameters>::OverrideEndpoint(std::string const&) [clone .localalias]':
/usr/include/aws/core/endpoint/DefaultEndpointProvider.h:99: undefined reference to `Aws::Endpoint::BuiltInParameters::OverrideEndpoint(std::string const&, Aws::Http::Scheme const&)'
/usr/bin/ld: /tmp/ccmaPUVG.ltrans35.ltrans.o: in function `Aws::Endpoint::DefaultEndpointProvider<Aws::S3::S3ClientConfiguration, Aws::S3::Endpoint::S3BuiltInParameters, Aws::S3::Endpoint::S3ClientContextParameters>::OverrideEndpoint(std::string const&) [clone .localalias]':
/usr/include/aws/core/endpoint/DefaultEndpointProvider.h:99: undefined reference to `Aws::Endpoint::BuiltInParameters::OverrideEndpoint(std::string const&, Aws::Http::Scheme const&)'
/usr/bin/ld: /tmp/ccmaPUVG.ltrans35.ltrans.o: in function `nix::S3BinaryCacheStoreImpl::uploadFile(std::string const&, std::shared_ptr<std::iostream>, std::string const&, std::string const&)':
/build/nix-git/src/nix/src/libstore/s3-binary-cache-store.cc:397: undefined reference to `Aws::Transfer::TransferManager::UploadFile(std::shared_ptr<std::iostream> const&, std::string const&, std::string const&, std::string const&, std::map<std::string, std::string, std::less<std::string>, std::allocator<std::pair<std::string const, std::string> > > const&, std::shared_ptr<Aws::Client::AsyncCallerContext const> const&)'
/usr/bin/ld: /tmp/ccmaPUVG.ltrans36.ltrans.o:(.data.rel.ro+0x1908): undefined reference to `Aws::Utils::Logging::FormattedLogSystem::LogStream(Aws::Utils::Logging::LogLevel, char const*, std::basic_ostringstream<char, std::char_traits<char>, std::allocator<char> > const&)'
collect2: error: ld returned 1 exit status
make: *** [mk/lib.mk:118: src/libstore/libnixstore.so] Error 1
rm src/nix/doc/files/profiles.md
  ```
</details>