### PR TITLE
texpresso: remove dependency on libmupdf.so

### DIFF
--- a/texpresso-git/.SRCINFO
+++ b/texpresso-git/.SRCINFO
@@ -26,7 +26,6 @@ pkgbase = texpresso-git
 	depends = libjpeg-turbo
 	depends = libjpeg.so
 	depends = libmupdf
-	depends = libmupdf.so
 	depends = libpng
 	depends = libpng16.so
 	depends = openjpeg2

--- a/texpresso-git/PKGBUILD
+++ b/texpresso-git/PKGBUILD
@@ -22,7 +22,7 @@ depends=(fontconfig libfontconfig.so
          icu libicuuc.so
          jbig2dec # libjbig2dec.so
          libjpeg-turbo libjpeg.so
-         libmupdf libmupdf.so
+         libmupdf # libmupdf.so
          libpng libpng16.so
          openjpeg2 # libopenjp2.so
          openssl libcrypto.so libssl.so


### PR DESCRIPTION
Otherwise installation fails after a successful build with message:

warning: cannot resolve "libmupdf.so=libmupdf.so-64", a dependency of "texpresso-git"

The dependency on libmupdf (the package) is kept.