### PR TITLE
Set arch to any

### DIFF
--- a/depot-tools-git/.SRCINFO
+++ b/depot-tools-git/.SRCINFO
@@ -1,15 +1,14 @@
 pkgbase = depot-tools-git
 	pkgdesc = Tools for working with Chromium development
-	pkgver = r11139.fcb617891
+	pkgver = r11144.19548ed7a
 	pkgrel = 1
 	url = https://chromium.googlesource.com/chromium/tools/depot_tools
 	install = depot-tools-git.install
 	arch = any
 	license = custom
+	depends = bash
 	depends = git
-	depends = glibc
 	depends = python
-	depends = java-runtime
 	source = git+https://chromium.googlesource.com/chromium/tools/depot_tools.git
 	sha512sums = SKIP
 

--- a/depot-tools-git/.SRCINFO
+++ b/depot-tools-git/.SRCINFO
@@ -1,10 +1,10 @@
 pkgbase = depot-tools-git
 	pkgdesc = Tools for working with Chromium development
-	pkgver = r10928.55d065cc0
+	pkgver = r11139.fcb617891
 	pkgrel = 1
 	url = https://chromium.googlesource.com/chromium/tools/depot_tools
 	install = depot-tools-git.install
-	arch = x86_64
+	arch = any
 	license = custom
 	depends = git
 	depends = glibc

--- a/depot-tools-git/PKGBUILD
+++ b/depot-tools-git/PKGBUILD
@@ -12,10 +12,10 @@
 # Contributor: Rustmilian <Rustmilian@proton.me>
 
 pkgname=depot-tools-git
-pkgver=r10928.55d065cc0
+pkgver=r11139.fcb617891
 pkgrel=1
 pkgdesc='Tools for working with Chromium development'
-arch=(x86_64)
+arch=(any)
 url='https://chromium.googlesource.com/chromium/tools/depot_tools'
 license=(custom)
 depends=(git glibc python java-runtime)

--- a/depot-tools-git/PKGBUILD
+++ b/depot-tools-git/PKGBUILD
@@ -12,13 +12,13 @@
 # Contributor: Rustmilian <Rustmilian@proton.me>
 
 pkgname=depot-tools-git
-pkgver=r11139.fcb617891
+pkgver=r11144.19548ed7a
 pkgrel=1
 pkgdesc='Tools for working with Chromium development'
 arch=(any)
 url='https://chromium.googlesource.com/chromium/tools/depot_tools'
 license=(custom)
-depends=(git glibc python java-runtime)
+depends=(bash git python)
 install="$pkgname.install"
 source=("git+$url.git")
 sha512sums=('SKIP')


### PR DESCRIPTION
This package doesn't have any elf files.
This was changed in 2021, did it have any back then? https://aur.archlinux.org/cgit/aur.git/commit/?h=depot-tools-git&id=c28ab9e3402cc39494b7ed6e281c4727e89de147