### PR TITLE
[python-skia-pathops] Use python-installer to install

### DIFF
--- a/python-skia-pathops/.SRCINFO
+++ b/python-skia-pathops/.SRCINFO
@@ -1,11 +1,11 @@
 pkgbase = python-skia-pathops
 	pkgdesc = Python bindings for the Skia library’s Path Ops (wheel)
 	pkgver = 0.8.0.post2
-	pkgrel = 2
+	pkgrel = 3
 	url = https://github.com/fonttools/skia-pathops
 	arch = x86_64
 	license = BSD-3-Clause
-	makedepends = python-pip
+	makedepends = python-installer
 	depends = python
 	options = !strip
 	source = https://files.pythonhosted.org/packages/cp313/s/skia-pathops/skia_pathops-0.8.0.post2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl

--- a/python-skia-pathops/PKGBUILD
+++ b/python-skia-pathops/PKGBUILD
@@ -4,13 +4,13 @@
 pkgname=python-skia-pathops
 _pkgname=${pkgname#python-}
 pkgver=0.8.0.post2
-pkgrel=2
+pkgrel=3
 pkgdesc='Python bindings for the Skia library’s Path Ops (wheel)'
 arch=(x86_64)
 url="https://github.com/fonttools/$_pkgname"
 license=(BSD-3-Clause)
 depends=(python)
-makedepends=(python-pip)
+makedepends=(python-installer)
 options=(!strip)
 _py=cp313
 _wheel="${_pkgname/-/_}-$pkgver-$_py-$_py-manylinux_2_17_$CARCH.manylinux2014_$CARCH.whl"
@@ -25,6 +25,6 @@ sha256sums=('7db6b12d5cd85d0dec27f8f4ff41f8e2befa76a40170cda9715f98d2002d0da1')
 
 package() {
 	export PIP_CONFIG_FILE=/dev/null
-	pip install --isolated --root="$pkgdir" --ignore-installed --no-deps $_wheel
+	python -m installer --destdir="$pkgdir" $_wheel
 	python -O -m compileall "$pkgdir"
 }


### PR DESCRIPTION
pkgrel bump, because the package is technically different, lacks pip related files:
`usr/lib/python3.13/site-packages/skia_pathops-0.8.0.post2.dist-info/direct_url.json`
`usr/lib/python3.13/site-packages/skia_pathops-0.8.0.post2.dist-info/INSTALLER`
`usr/lib/python3.13/site-packages/skia_pathops-0.8.0.post2.dist-info/REQUESTED`