### PR TITLE
fix: Bump afdko release to 4.0.2-3 and built with minimum required CMAKE version

### DIFF
--- a/afdko/.SRCINFO
+++ b/afdko/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = afdko
 	pkgdesc = Adobe Font Development Kit for OpenType
 	pkgver = 4.0.2
-	pkgrel = 2
+	pkgrel = 3
 	url = https://github.com/adobe-type-tools/afdko
 	arch = x86_64
 	license = Apache-2.0

--- a/afdko/PKGBUILD
+++ b/afdko/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=afdko
 pkgver=4.0.2
-pkgrel=2
+pkgrel=3
 pkgdesc='Adobe Font Development Kit for OpenType'
 arch=(x86_64)
 url="https://github.com/adobe-type-tools/$pkgname"
@@ -47,7 +47,7 @@ prepare () {
 
 build() {
 	cd "$_archive"
-	python -m build -wn
+	CMAKE_POLICY_VERSION_MINIMUM=3.5 python -m build -wn
 }
 
 check() {


### PR DESCRIPTION
due to update of libxml2 dependency

Regarding the CMAKE version, see the following comment: https://aur.archlinux.org/packages/afdko#comment-1021015

As far as I can tell it should be no problem, as the cmake of Arch is at version 4.0.x