### PR TITLE
Update ghostty PKGBUILD

### DIFF
--- a/ghostty-git/PKGBUILD
+++ b/ghostty-git/PKGBUILD
@@ -4,7 +4,7 @@
 
 _pkgbase=ghostty
 pkgname=($_pkgbase-git $_pkgbase-shell-integration-git $_pkgbase-terminfo-git)
-pkgrel=1
+pkgrel=2
 pkgver=1.1.2.r262.gefc1b10
 pkgdesc="Fast, native, feature-rich terminal emulator pushing modern features"
 arch=(x86_64 aarch64 i686)
@@ -16,7 +16,7 @@ depends=(bzip2
          gcc-libs # ld-linux-x86-64.so
          glibc # libc.so libm.so
          glib2 libglib-2.0.so libgio-2.0.so libgobject-2.0.so
-         gtk4 libgtk-4.so
+         gtk4 libgtk-4.so gtk4-layer-shell
          libx11 # libX11.so
          harfbuzz libharfbuzz.so
          libadwaita libadwaita-1.so


### PR DESCRIPTION
This adds gtk4-layer-shell, which is needed to successfully build ghostty. Without it the build fails.

I have built and checked that with this update the the package now successfully builds.

Thanks for maintaining the package.