### PR TITLE
upgpkg: python-skia-pathops 0.9.1

### DIFF
--- a/python-skia-pathops/.SRCINFO
+++ b/python-skia-pathops/.SRCINFO
@@ -1,14 +1,14 @@
 pkgbase = python-skia-pathops
 	pkgdesc = Python bindings for the Skia library’s Path Ops (wheel)
-	pkgver = 0.8.0.post2
-	pkgrel = 4
+	pkgver = 0.9.1
+	pkgrel = 1
 	url = https://github.com/fonttools/skia-pathops
 	arch = x86_64
 	license = BSD-3-Clause
 	makedepends = python-installer
 	depends = python
 	options = !strip
-	source = https://files.pythonhosted.org/packages/cp313/s/skia-pathops/skia_pathops-0.8.0.post2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-	sha256sums = 7db6b12d5cd85d0dec27f8f4ff41f8e2befa76a40170cda9715f98d2002d0da1
+	source = https://files.pythonhosted.org/packages/cp310/s/skia-pathops/skia_pathops-0.9.1-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+	sha256sums = 3a5eee648d4acff631b8eaca13984a288886bbf754999b940da85ea3bcb4b9a9
 
 pkgname = python-skia-pathops

--- a/python-skia-pathops/PKGBUILD
+++ b/python-skia-pathops/PKGBUILD
@@ -3,8 +3,8 @@
 
 pkgname=python-skia-pathops
 _pkgname=${pkgname#python-}
-pkgver=0.8.0.post2
-pkgrel=4
+pkgver=0.9.1
+pkgrel=1
 pkgdesc='Python bindings for the Skia library’s Path Ops (wheel)'
 arch=(x86_64)
 url="https://github.com/fonttools/$_pkgname"
@@ -12,10 +12,10 @@ license=(BSD-3-Clause)
 depends=(python)
 makedepends=(python-installer)
 options=(!strip)
-_py=cp313
-_wheel="${_pkgname/-/_}-$pkgver-$_py-$_py-manylinux_2_17_$CARCH.manylinux2014_$CARCH.whl"
+_py=cp310
+_wheel="${_pkgname/-/_}-${pkgver}-${_py}-abi3-manylinux2014_${CARCH}.manylinux_2_17_${CARCH}.whl"
 source=("https://files.pythonhosted.org/packages/$_py/${_pkgname::1}/$_pkgname/$_wheel")
-sha256sums=('7db6b12d5cd85d0dec27f8f4ff41f8e2befa76a40170cda9715f98d2002d0da1')
+sha256sums=('3a5eee648d4acff631b8eaca13984a288886bbf754999b940da85ea3bcb4b9a9')
 
 # If anybody wants to mess around with the Chromium tree and figure out how to
 # build skia from source on Arch I'm open to patches, but even after mucking


### PR DESCRIPTION
Currently the package does not work, as the files for the wrong python (3.1.3) version are installed (therefore the tests for `python-ufo2ft` fail).

Note the release notes from 0.9.0:
> Build and upload .abi3 wheels that use CPython's Py_LIMITED_API: the same cp310-abi3-* wheel works with all Pythons >= 3.10 on the same platform/architecture. We went from 45 wheels down to 12.

https://github.com/fonttools/skia-pathops/releases/tag/v0.9.0