### PR TITLE
Fix graphite-editor-git with changed build process

### DIFF
--- a/graphite-editor-git/PKGBUILD
+++ b/graphite-editor-git/PKGBUILD
@@ -41,6 +41,7 @@ prepare() {
 	cargo fetch --locked --target "$(rustc --print host-tuple)"
 	pushd frontend
 	npm run setup
+	cargo run --package third-party-licenses --features desktop
 }
 
 pkgver() {


### PR DESCRIPTION
`graphite-editor`'s desktop [build process changed about a month ago](https://github.com/GraphiteEditor/Graphite/commit/5d222920728eeaabc232dd52cd1e8f4405c91fbc) to move several build steps out of `npm`... but not into the normal `cargo build` process, and instead into a manually defined `cargo run` process. The only change not already captured by the existing PKGBUILD is a generation of external licenses step. This leads to an error during build:

```
error: couldn't read `[$pkg]/src/graphite-editor-git/desktop/third-party-licenses.txt.xz`: No such file or directory (os error 2)
```

per [the script that gets called](https://github.com/GraphiteEditor/Graphite/blob/master/tools/cargo-run/src/main.rs) by `cargo run` in `graphite-editor` and discussion at [the AUR entry](https://aur.archlinux.org/packages/graphite-editor-git), I've added the line  
```
cargo run --package third-party-licenses --features desktop
```
to the PKGBUILD's prepare step. I've confirmed this works and successfully builds the package.

Thanks!