### PR TITLE
fix(gitbutler): set `CHANNEL=release` for the build

### DIFF
--- a/gitbutler/PKGBUILD
+++ b/gitbutler/PKGBUILD
@@ -53,6 +53,7 @@ build() {
 	export OPENSSL_NO_VENDOR=true
 	export LIBGIT2_NO_VENDOR=1
 	export TURBO_TELEMETRY_DISABLED=1
+	export CHANNEL=release
 
 	# keep in sync with crates/gitbutler-tauri/tauri.conf.release.json
 	pnpm build:desktop -- --mode production


### PR DESCRIPTION
GitButler's internals uses the `CHANNEL` environment variable at build time to determine the kind of build that's being produced. Among other things, this affects where app data, cache and logs appear, but also what endpoints the login flow accesses.

If `CHANNEL` is not set, the build defaults to dev semantics.

IMPORTANT: In setting `CHANNEL=release`, any existing users of this AUR package will have GitButler suddenly "forget" about their projects, forge integrations, etc. The VCS data is still there, but hey need to re-add any projects they have and setup inegrations anew.