### PR TITLE
fix(gfmetadata): Remove python tests, as there are none

### DIFF
--- a/python-gfmetadata/PKGBUILD
+++ b/python-gfmetadata/PKGBUILD
@@ -24,11 +24,6 @@ build() {
 	python -m build -wn
 }
 
-check() {
-	cd "$_archive"
-	PYTHONPATH=Lib pytest
-}
-
 package() {
 	cd "$_archive"
 	python -m installer -d "$pkgdir" dist/*.whl


### PR DESCRIPTION
There are actually no python test for the `python-gfmetadata` package, see also the Github pipeline, it is only an import of the module: https://github.com/googlefonts/gf-metadata/blob/main/.github/workflows/test-publish-release.yaml#L86-L110 

This leads to a failure of the check step of the `python-gfmetadata` package: 
```
Successfully built gfmetadata-0.2.5-py3-none-any.whl
==> Beginne check()...
============================================================== test session starts ===============================================================
platform linux -- Python 3.14.6, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/max/aurget/python-gfmetadata/src/gfmetadata-0.2.5
configfile: pyproject.toml
plugins: typeguard-4.5.2, anyio-4.14.1, syrupy-5.3.4
collected 0 items                                                                                                                                

============================================================= no tests ran in 0.01s ==============================================================
==> FEHLER: Ein Fehler geschah in check().
    Breche ab...
```