### PR TITLE
fix(ghostty-git): update build

### DIFF
--- a/ghostty-git/PKGBUILD
+++ b/ghostty-git/PKGBUILD
@@ -1,5 +1,6 @@
 # Maintainer: Gregory Anders <greg at gpanders dot com>
 # Maintainer: Caleb Maclennan <caleb@alerque.com>
+# Contributor: Akilesh A S <io@akileshas.dev>
 # Contributor: kaij <contact at kaij dot tech>
 
 _pkgbase=ghostty

--- a/ghostty-git/PKGBUILD
+++ b/ghostty-git/PKGBUILD
@@ -49,7 +49,6 @@ build() {
 	DESTDIR=build zig build \
 		--summary all \
 		--prefix "/usr" \
-		--system "$srcdir/zig-global-cache/p" \
 		-Doptimize=ReleaseFast \
 		-Dgtk-wayland=true \
 		-Dgtk-x11=true \

--- a/ghostty-git/PKGBUILD
+++ b/ghostty-git/PKGBUILD
@@ -5,7 +5,7 @@
 _pkgbase=ghostty
 pkgname=($_pkgbase-git $_pkgbase-shell-integration-git $_pkgbase-terminfo-git)
 pkgrel=1
-pkgver=1.1.2.r1185.gd0f116d
+pkgver=1.3.1.r1193.g8b71d7a
 pkgdesc="Fast, native, feature-rich terminal emulator pushing modern features"
 arch=(x86_64 aarch64 i686)
 url="https://github.com/ghostty-org/$_pkgbase"


### PR DESCRIPTION
### TL;DR:
- bump `pkgver` to `1.3.1.r1193.g8b71d7a`.
- removed the `--system` flag during `zig build` (because, it forces strict offline constraints and alters default linking behaviors and occurs some conflict after some updates in the upstream ghostty/zig).
- now, builds without any issues.